### PR TITLE
Verbose option

### DIFF
--- a/_examples/Makefile
+++ b/_examples/Makefile
@@ -1,4 +1,6 @@
-export DEBUG ?= 1
+export DEBUG ?= 0
+export VERBOSE ?= 1
+
 default: 00 01 10 11
 
 00:

--- a/code/config.go
+++ b/code/config.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log"
+	"os"
+	"strconv"
 
 	"github.com/podhmo/apikit/pkg/tinypkg"
 	"github.com/podhmo/apikit/resolve"
@@ -16,20 +19,32 @@ const (
 )
 
 type EmitCodeFunc func(w io.Writer, e *CodeEmitter) error
-
+type Logger interface {
+	Printf(fmt string, args ...interface{})
+}
 type Config struct {
 	Header        string
 	DisableFormat bool
 
 	EmitCodeFunc EmitCodeFunc
 	Resolver     *resolve.Resolver
+
+	Log     Logger
+	Verbose bool
 }
 
 func DefaultConfig() *Config {
+	verbose := false
+	if v, err := strconv.ParseBool(os.Getenv("VERBOSE")); err == nil {
+		verbose = v
+	}
+
 	c := &Config{
 		Header:        Header,
 		DisableFormat: false,
+		Log:           log.New(os.Stderr, "", 0),
 		Resolver:      resolve.NewResolver(),
+		Verbose:       verbose,
 	}
 	c.EmitCodeFunc = c.defaultEmitCodeFunc
 	return c

--- a/code/config.go
+++ b/code/config.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
-	"os"
-	"strconv"
 
 	"github.com/podhmo/apikit/pkg/tinypkg"
 	"github.com/podhmo/apikit/resolve"
@@ -19,32 +16,23 @@ const (
 )
 
 type EmitCodeFunc func(w io.Writer, e *CodeEmitter) error
-type Logger interface {
-	Printf(fmt string, args ...interface{})
-}
 type Config struct {
+	*resolve.Config
+
 	Header        string
 	DisableFormat bool
 
 	EmitCodeFunc EmitCodeFunc
 	Resolver     *resolve.Resolver
-
-	Log     Logger
-	Verbose bool
 }
 
 func DefaultConfig() *Config {
-	verbose := false
-	if v, err := strconv.ParseBool(os.Getenv("VERBOSE")); err == nil {
-		verbose = v
-	}
-
+	resolver := resolve.NewResolver()
 	c := &Config{
 		Header:        Header,
 		DisableFormat: false,
-		Log:           log.New(os.Stderr, "", 0),
-		Resolver:      resolve.NewResolver(),
-		Verbose:       verbose,
+		Resolver:      resolver,
+		Config:        resolver.Config,
 	}
 	c.EmitCodeFunc = c.defaultEmitCodeFunc
 	return c

--- a/pkg/emitfile/emitfile.go
+++ b/pkg/emitfile/emitfile.go
@@ -109,10 +109,6 @@ func (e *Executor) Emit() error {
 			return fmt.Errorf("resolve-path is failed in action=%q: %w", action.Name, err)
 		}
 
-		if e.Verbose {
-			e.Log.Printf("\tF emit   %s", fpath) // todo: detect Create Or Update Or Deletee (?)
-		}
-
 		buf := new(bytes.Buffer)
 		if err := action.Target.Emit(buf); err != nil {
 			return fmt.Errorf("emit-func is failed in action=%q: %w", action.Name, err)
@@ -127,6 +123,7 @@ func (e *Executor) Emit() error {
 				b = output
 			}
 		}
+
 		if err := WriteOrCreateFile(fpath, b, e.Config); err != nil {
 			return fmt.Errorf("write-file is failed in action=%q: %w", action.Name, err)
 		}

--- a/pkg/emitfile/emitfile.go
+++ b/pkg/emitfile/emitfile.go
@@ -72,7 +72,7 @@ func New(rootdir string) *Executor {
 		c.Verbose = true
 		c.AlwaysWrite = true
 	}
-	r := newPathResolver(rootdir)
+	r := newPathResolver(rootdir, c)
 	r.Config = c
 	return &Executor{
 		PathResolver: r,
@@ -136,9 +136,10 @@ type PathResolver struct {
 	RootDirs map[string]string
 }
 
-func newPathResolver(rootdir string) *PathResolver {
+func newPathResolver(rootdir string, config *Config) *PathResolver {
 	return &PathResolver{
 		RootDirs: map[string]string{"/": rootdir},
+		Config:   config,
 	}
 }
 

--- a/pkg/emitfile/emitfile_test.go
+++ b/pkg/emitfile/emitfile_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 )
 
+type fakeLogger struct{}
+
+func (l *fakeLogger) Printf(fmt string, args ...interface{}) {}
+
 func TestPathResolver(t *testing.T) {
 	cases := []struct {
 		rootdir string
@@ -89,7 +93,7 @@ func TestPathResolver(t *testing.T) {
 	for _, c := range cases {
 		c := c
 		t.Run(c.pkgpath, func(t *testing.T) {
-			r := newPathResolver(c.rootdir)
+			r := newPathResolver(c.rootdir, &Config{Log: &fakeLogger{}})
 			if c.modify != nil {
 				c.modify(r)
 			}

--- a/pkg/emitfile/fileutil.go
+++ b/pkg/emitfile/fileutil.go
@@ -9,9 +9,12 @@ import (
 var mkdirSentinelMap = map[string]bool{}
 
 func WriteOrCreateFile(path string, b []byte, config *Config) error {
-	if config.Debug {
-		config.Log.Printf("write %s", path)
-	}
+	defer func() {
+		if config.Verbose {
+			config.Log.Printf("\tF create %s", path) // todo: detect Create Or Update Or Delete (?)
+		}
+	}()
+
 	if err := ioutil.WriteFile(path, b, 0666); err != nil {
 		dirpath := filepath.Dir(path)
 		if _, ok := mkdirSentinelMap[dirpath]; ok {

--- a/pkg/emitfile/fileutil.go
+++ b/pkg/emitfile/fileutil.go
@@ -2,16 +2,15 @@ package emitfile
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 )
 
 var mkdirSentinelMap = map[string]bool{}
 
-func WriteOrCreateFile(path string, b []byte) error {
-	if DEBUG {
-		log.Printf("write %s", path)
+func WriteOrCreateFile(path string, b []byte, config *Config) error {
+	if config.Debug {
+		config.Log.Printf("write %s", path)
 	}
 	if err := ioutil.WriteFile(path, b, 0666); err != nil {
 		dirpath := filepath.Dir(path)
@@ -20,9 +19,9 @@ func WriteOrCreateFile(path string, b []byte) error {
 		}
 
 		mkdirSentinelMap[dirpath] = true
-		log.Printf("INFO: directory is not found, try to create %s", dirpath)
+		config.Log.Printf("\tD create %s", dirpath)
 		if err := os.MkdirAll(dirpath, 0744); err != nil {
-			log.Printf("ERROR: %s", err)
+			config.Log.Printf("ERROR: %s", err)
 			return err
 		}
 		return ioutil.WriteFile(path, b, 0666)

--- a/resolve/config.go
+++ b/resolve/config.go
@@ -1,0 +1,34 @@
+package resolve
+
+import (
+	"log"
+	"os"
+	"strconv"
+)
+
+type Logger interface {
+	Printf(fmt string, args ...interface{})
+}
+
+type Config struct {
+	Log     Logger
+	Verbose bool
+	Debug   bool
+}
+
+func DefaultConfig() *Config {
+	verbose := false
+	if v, err := strconv.ParseBool(os.Getenv("VERBOSE")); err == nil {
+		verbose = v
+	}
+	debug := false
+	if v, err := strconv.ParseBool(os.Getenv("DEBUG")); err == nil {
+		debug = v
+	}
+
+	return &Config{
+		Log:     log.New(os.Stderr, "", 0),
+		Verbose: verbose,
+		Debug:   debug,
+	}
+}

--- a/resolve/resolve.go
+++ b/resolve/resolve.go
@@ -13,6 +13,8 @@ import (
 )
 
 type Resolver struct {
+	Config *Config
+
 	extractor *reflectshape.Extractor
 	universe  *tinypkg.Universe
 
@@ -29,6 +31,7 @@ func NewResolver() *Resolver {
 		RevisitArglist: true,
 	}
 	return &Resolver{
+		Config:         DefaultConfig(),
 		extractor:      e,
 		universe:       tinypkg.NewUniverse(),
 		symbolsCache:   map[reflectshape.Identity][]*symbolCacheItem{},

--- a/resolve/tracker.go
+++ b/resolve/tracker.go
@@ -75,7 +75,13 @@ func (t *Tracker) Override(name string, providerFunc interface{}) (prev *Def, er
 	if rt.Kind() != reflect.Func {
 		return nil, fmt.Errorf("unexpected providerFunc, only function %v", rt)
 	}
-	return t.overrideByDef(rt.Out(0), name, t.Resolver.Def(providerFunc)), nil
+
+	targetType := rt.Out(0)
+	def := t.Resolver.Def(providerFunc)
+	if t.Resolver.Config.Verbose {
+		t.Resolver.Config.Log.Printf("\t! override provider[name=%q] = %s.%s [type=%s]", name, def.Package.Path, def.Symbol, rt)
+	}
+	return t.overrideByDef(targetType, name, def), nil
 }
 
 func (t *Tracker) overrideByDef(rt reflect.Type, name string, def *Def) (prev *Def) {

--- a/web/webgen/gen-chi/gen.go
+++ b/web/webgen/gen-chi/gen.go
@@ -71,11 +71,6 @@ func (c *Config) New(emitter *emitgo.Emitter) *Generator {
 		Verbose: g.Verbose,
 		Log:     g.Log,
 	}
-
-	g.RuntimePkg = rootpkg.Relative("runtime", "")
-	g.HandlerPkg = rootpkg.Relative("handler", "")
-	g.ProviderPkg = g.HandlerPkg
-	g.RouterPkg = g.HandlerPkg
 	return g
 }
 
@@ -84,6 +79,19 @@ func (g *Generator) Generate(
 	r *web.Router,
 	getHTTPStatusFromError func(error) int,
 ) error {
+	if g.RuntimePkg == nil {
+		g.RuntimePkg = g.RootPkg.Relative("runtime", "")
+	}
+	if g.HandlerPkg == nil {
+		g.HandlerPkg = g.RootPkg.Relative("handler", "")
+	}
+	if g.ProviderPkg == nil {
+		g.ProviderPkg = g.HandlerPkg
+	}
+	if g.RouterPkg == nil {
+		g.RouterPkg = g.HandlerPkg
+	}
+
 	g.Log.Printf("detect target packages ...")
 	if g.Verbose {
 		g.Log.Printf("\t* runtime package -> %s", g.RuntimePkg.Path)

--- a/web/webgen/gen-chi/gen.go
+++ b/web/webgen/gen-chi/gen.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,8 +19,11 @@ import (
 
 type Config struct {
 	*code.Config
-	Tracker      *resolve.Tracker
+
+	Tracker *resolve.Tracker
+
 	ProviderName string
+	Verbose      bool
 }
 
 func DefaultConfig() *Config {
@@ -39,7 +43,8 @@ func (c *Config) NewPackage(path, name string) *tinypkg.Package {
 }
 
 type Generator struct {
-	Config  *Config
+	*Config
+
 	Emitter *emitgo.Emitter
 	Tracker *resolve.Tracker
 
@@ -70,6 +75,13 @@ func (g *Generator) Generate(
 	r *web.Router,
 	getHTTPStatusFromError func(error) int,
 ) error {
+	if g.Verbose {
+		log.Printf("* runtime package -> %s", g.RuntimePkg.Path)
+		log.Printf("* handler package -> %s", g.HandlerPkg.Path)
+		log.Printf("* provider package -> %s", g.ProviderPkg.Path)
+		log.Printf("* router package -> %s", g.RouterPkg.Path)
+	}
+
 	resolver := g.Tracker.Resolver
 	providerModule, err := ProviderModule(g.ProviderPkg, resolver, g.Config.ProviderName)
 	if err != nil {

--- a/web/webgen/gen-chi/to_handler.go
+++ b/web/webgen/gen-chi/to_handler.go
@@ -20,6 +20,10 @@ func (t *Translator) TranslateToHandler(here *tinypkg.Package, node *web.WalkerN
 	}
 	t.Tracker.Track(def)
 
+	if t.Config.Verbose {
+		t.Config.Log.Printf("\t+ translate %s.%s -> handler %s.%s", def.Package.Path, def.Symbol, here.Path, name)
+	}
+
 	c := &code.Code{
 		Name: name,
 		Here: here,


### PR DESCRIPTION
```console
$ go run 11web/gen.go
	! override provider[name="db"] = m/11web/design.NewDB [type=func(context.Context) (*design.DB, error)]
detect target packages ...
	* runtime package -> m/11web/runtime
	* handler package -> m/11web/handler
	* provider package -> m/11web/handler
	* router package -> m/11web/handler
generate handler package ...
	+ translate m/11web/design.PostArticleComment -> handler m/11web/handler.PostArticleComment
	+ translate m/11web/design.ListArticle -> handler m/11web/handler.ListArticle
	+ translate m/11web/design.GetArticle -> handler m/11web/handler.GetArticle
generate router package ...
	+ generate m/11web/handler.Mount()
generate runtime package ...
	+ generate runtime (almost copy)
	+ generate HandleResult() with design.HTTPStatusOf
emit files ...
	F create C:\Users\me\ghq\github.com\podhmo\apikit\_examples\11web\handler\PostArticleComment.go
	F create C:\Users\me\ghq\github.com\podhmo\apikit\_examples\11web\handler\ListArticle.go
	F create C:\Users\me\ghq\github.com\podhmo\apikit\_examples\11web\handler\GetArticle.go
	F create C:\Users\me\ghq\github.com\podhmo\apikit\_examples\11web\handler\mount.go
	F create C:\Users\me\ghq\github.com\podhmo\apikit\_examples\11web\handler\Provider.go
	F create C:\Users\me\ghq\github.com\podhmo\apikit\_examples\11web\runtime\runtime.go
	F create C:\Users\me\ghq\github.com\podhmo\apikit\_examples\11web\runtime\HandleResult.go
```