### PR TITLE
fix: code generation, if file is not exists, force execution

### DIFF
--- a/pkg/emitfile/emitfile.go
+++ b/pkg/emitfile/emitfile.go
@@ -241,6 +241,11 @@ func (e *Executor) emitWithManagement() error {
 		if e.Config.Clean && r.Type != classify.ResultTypeDelete {
 			r.Type = classify.ResultTypeCreate
 		}
+		if r.Type == classify.ResultTypeNotChanged {
+			if _, err := os.Stat(r.Name()); err != nil && os.IsNotExist(err) {
+				r.Type = classify.ResultTypeCreate
+			}
+		}
 
 		switch r.Type {
 		case classify.ResultTypeCreate, classify.ResultTypeUpdate:


### PR DESCRIPTION
- in .apikit.hist.json foo.go is existed
- and state is no-changed
- but actual file is not existed